### PR TITLE
Multi DB integration

### DIFF
--- a/src/HitableBehavior.php
+++ b/src/HitableBehavior.php
@@ -36,6 +36,10 @@ class HitableBehavior extends Behavior
      */
     public $delay = 86400;
     /**
+     * @var \yii\base\Component
+     */
+    public $db = false;
+    /**
      * @var string
      */
     public $table_name = '{{%hits}}';
@@ -48,6 +52,9 @@ class HitableBehavior extends Behavior
         if (!$this->attribute) {
             throw new IntegrityException('Attribute is not defined');
         }
+        
+        if(!$this->db)
+            $this->db = $this->owner->getDb();
 
         parent::init();
     }
@@ -93,7 +100,7 @@ class HitableBehavior extends Behavior
      */
     private function storeHit()
     {
-        return $this->owner->getDb()->createCommand()
+        return $this->db->createCommand()
             ->insert($this->table_name, [
                 'user_agent' => Yii::$app->getRequest()->getUserAgent(),
                 'ip' => Yii::$app->getRequest()->getUserIP(),


### PR DESCRIPTION
Add cross DB integration (for example counter in Mongo DB and hits table in mysql) or same.
Need just add **'db' => Yii::$app->db** to the hit params inside behaviors.
Full example:
```
    public function behaviors()
    {
        return [
            'hit' => [
                'class' => HitableBehavior::className(),
                'attribute' => 'views',    //attribute which should contain uniquie hits value
                'group' => false,               //group name of the model (class name by default)
                'delay' => 60 * 60,             //register the same visitor every hour
                'db' => Yii::$app->db,          //cross DB connection (optional)
                'table_name' => '{{%hits}}'     //table with hits data
            ]
        ];
    }
```